### PR TITLE
Downgrade schnorrkel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bip39"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
Substrate still dependent `0.9.1`, if the optional `schnorrkel` enabled, in our case, it make compiles failed

```
error[E0308]: mismatched types
   --> substrate/primitives/core/src/sr25519.rs:600:33
    |
600 |           let mini_key: MiniSecretKey = mini_secret_from_entropy(entropy, password.unwrap_or(""))
    |  _______________________-------------___^
    | |                       |
    | |                       expected due to this
601 | |             .expect("32 bytes can always build a key; qed");
    | |___________________________________________________________^ expected struct `MiniSecretKey`, found struct `schnorrkel::keys::MiniSecretKey`
    |
    = note: perhaps two different versions of crate `schnorrkel` are being used?
```